### PR TITLE
Fix: Show loading screen immediately when starting any game

### DIFF
--- a/react/react/src/App.tsx
+++ b/react/react/src/App.tsx
@@ -113,6 +113,9 @@ function App() {
   };
 
   const handleQuickPlay = async () => {
+    // Immediately switch to table view to show loading screen
+    setCurrentView('table');
+    
     try {
       const response = await fetch(`${config.API_URL}/api/new-game`, {
         method: 'POST',
@@ -126,10 +129,15 @@ function App() {
       if (response.ok) {
         const data = await response.json();
         setGameId(data.game_id);
-        setCurrentView('table');
+      } else {
+        // If creation fails, go back to menu
+        console.error('Failed to create game');
+        setCurrentView('game-menu');
       }
     } catch (error) {
       console.error('Failed to create game:', error);
+      // If creation fails, go back to menu
+      setCurrentView('game-menu');
     }
   };
 
@@ -146,6 +154,9 @@ function App() {
   };
 
   const handleStartCustomGame = async (selectedPersonalities: string[]) => {
+    // Immediately switch to table view to show loading screen
+    setCurrentView('table');
+    
     try {
       const response = await fetch(`${config.API_URL}/api/new-game`, {
         method: 'POST',
@@ -162,15 +173,23 @@ function App() {
       if (response.ok) {
         const data = await response.json();
         setGameId(data.game_id);
-        setCurrentView('table');
+      } else {
+        // If creation fails, go back to custom game view
+        console.error('Failed to create custom game');
+        setCurrentView('custom-game');
       }
     } catch (error) {
       console.error('Failed to create custom game:', error);
+      // If creation fails, go back to custom game view
+      setCurrentView('custom-game');
     }
   };
 
   const handleSelectTheme = async (theme: Theme) => {
     if (!theme.personalities) return;
+    
+    // Immediately switch to table view to show loading screen
+    setCurrentView('table');
     
     try {
       const response = await fetch(`${config.API_URL}/api/new-game`, {
@@ -188,10 +207,15 @@ function App() {
       if (response.ok) {
         const data = await response.json();
         setGameId(data.game_id);
-        setCurrentView('table');
+      } else {
+        // If creation fails, go back to themed game view
+        console.error('Failed to create themed game');
+        setCurrentView('themed-game');
       }
     } catch (error) {
       console.error('Failed to create themed game:', error);
+      // If creation fails, go back to themed game view
+      setCurrentView('themed-game');
     }
   };
 


### PR DESCRIPTION
## Summary
- Improved UX by showing loading screen immediately when users click to start a game
- Applied fix to all three game start methods: Quick Play, Custom Game, and Theme Games
- Added proper error handling to return users to the appropriate menu on failure

## Changes
1. **Modified game start handlers in App.tsx**:
   - `handleQuickPlay`: Now shows loading screen immediately
   - `handleStartCustomGame`: Now shows loading screen immediately  
   - `handleSelectTheme`: Now shows loading screen immediately

2. **Updated PokerTable component**:
   - Removed duplicate game creation logic
   - Component now waits for gameId to be provided by parent
   - Shows loading screen while waiting for gameId

## Before
Users would click a game start button and see no visual feedback while the API request was being made, making it seem like the app was frozen.

## After
Users now see the animated loading screen with cards and "Setting up the table..." message immediately after clicking any game start option.

## Test Plan
- [x] Click Quick Play - loading screen appears immediately
- [x] Click Custom Game and select personalities - loading screen appears immediately
- [x] Click Theme Game and select a theme - loading screen appears immediately
- [x] Error handling returns to appropriate menu on failure

🤖 Generated with [Claude Code](https://claude.ai/code)