### PR TITLE
fix: display chat messages immediately after sending

### DIFF
--- a/react/react/src/components/chat/Chat/Chat.css
+++ b/react/react/src/components/chat/Chat/Chat.css
@@ -136,11 +136,6 @@
   line-height: 1.3;
 }
 
-.chat-message.game {
-  border-left-color: #4caf50;
-  background: rgba(76, 175, 80, 0.1);
-}
-
 .chat-message.system {
   border-left-color: #ff9800;
   background: rgba(255, 152, 0, 0.1);
@@ -149,6 +144,16 @@
 .chat-message.player {
   border-left-color: #2196f3;
   background: rgba(33, 150, 243, 0.1);
+}
+
+.chat-message.ai {
+  border-left-color: #9c27b0;
+  background: rgba(156, 39, 176, 0.1);
+}
+
+.chat-message.table {
+  border-left-color: #4caf50;
+  background: rgba(76, 175, 80, 0.1);
 }
 
 .chat-message.own-message {

--- a/react/react/src/components/chat/Chat/Chat.tsx
+++ b/react/react/src/components/chat/Chat/Chat.tsx
@@ -1,13 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
+import type { ChatMessage } from '../../../types';
 import './Chat.css';
-
-interface ChatMessage {
-  id: string;
-  sender: string;
-  message: string;
-  timestamp: string;
-  type: 'game' | 'player' | 'system';
-}
 
 interface ChatProps {
   messages: ChatMessage[];
@@ -46,12 +39,14 @@ export function Chat({ messages, onSendMessage, isVisible, onToggleVisibility, p
 
   const getMessageIcon = (type: string, sender: string) => {
     switch (type) {
-      case 'game':
-        return '🎯';
+      case 'table':
+        return '🎲';
       case 'system':
         return '⚙️';
+      case 'ai':
+        return '🤖';
       case 'player':
-        return sender === playerName ? '👤' : '🤖';
+        return sender === playerName ? '👤' : '💬';
       default:
         return '💬';
     }

--- a/react/react/src/components/chat/ChatSidebar/ChatSidebar.css
+++ b/react/react/src/components/chat/ChatSidebar/ChatSidebar.css
@@ -185,11 +185,6 @@
 }
 
 /* Message types */
-.chat-message.game {
-  border-left-color: #4caf50;
-  background: rgba(76, 175, 80, 0.08);
-}
-
 .chat-message.system {
   border-left-color: #ff9800;
   background: rgba(255, 152, 0, 0.08);
@@ -203,6 +198,11 @@
 .chat-message.ai {
   border-left-color: #9c27b0;
   background: rgba(156, 39, 176, 0.08);
+}
+
+.chat-message.table {
+  border-left-color: #4caf50;
+  background: rgba(76, 175, 80, 0.08);
 }
 
 .chat-message.own-message {

--- a/react/react/src/components/chat/ChatSidebar/ChatSidebar.tsx
+++ b/react/react/src/components/chat/ChatSidebar/ChatSidebar.tsx
@@ -1,15 +1,8 @@
 import { useState, useRef, useEffect, useMemo } from 'react';
+import type { ChatMessage } from '../../../types';
 import { useFeatureFlags } from '../../debug/FeatureFlags';
 import { QuickChatSuggestions } from '../QuickChatSuggestions';
 import './ChatSidebar.css';
-
-interface ChatMessage {
-  id: string;
-  sender: string;
-  message: string;
-  timestamp: string;
-  type: 'game' | 'player' | 'system' | 'ai' | 'table';
-}
 
 interface ChatSidebarProps {
   messages: ChatMessage[];
@@ -253,11 +246,12 @@ export function ChatSidebar({ messages, onSendMessage, playerName = 'Player', ga
     switch (type) {
       case 'action':
         return '🎮';
-      case 'game':
+      case 'table':
         return '🎲';
       case 'system':
         return '⚙️';
       case 'ai':
+        return '🤖';
       case 'player':
         return sender === playerName ? '👤' : '💬';
       default:

--- a/react/react/src/components/game/PokerTable/PokerTable.tsx
+++ b/react/react/src/components/game/PokerTable/PokerTable.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useRef } from 'react';
 import { io, Socket } from 'socket.io-client';
+import type { ChatMessage } from '../../../types';
 import { Card, CommunityCard, HoleCard } from '../../cards';
 import { ActionButtons } from '../ActionButtons';
 import { Chat } from '../../chat/Chat';
@@ -22,14 +23,6 @@ interface Player {
   is_all_in: boolean;
   is_human: boolean;
   hand?: string[];
-}
-
-interface ChatMessage {
-  id: string;
-  sender: string;
-  message: string;
-  timestamp: string;
-  type: 'game' | 'player' | 'system';
 }
 
 interface GameState {

--- a/react/react/src/types/chat.ts
+++ b/react/react/src/types/chat.ts
@@ -3,5 +3,17 @@ export interface ChatMessage {
   sender: string;
   message: string;
   timestamp: string;
-  type: 'game' | 'player' | 'system';
+  type: 'player' | 'ai' | 'table' | 'system';
+}
+
+/**
+ * Backend message format (before transformation to ChatMessage).
+ * Uses the same message_type values as ChatMessage.type.
+ */
+export interface BackendChatMessage {
+  id?: string;
+  sender: string;
+  content: string;
+  timestamp: string;
+  message_type: ChatMessage['type'];
 }


### PR DESCRIPTION
Add listener for 'new_messages' WebSocket event in GameContext. The
backend was already emitting this event when messages are sent, but
the frontend was only updating messages from 'update_game_state' events
which only fire on player turn changes. This caused sent messages to
not appear until the next player's turn.

The fix transforms the backend message format (content, message_type)
to the frontend format (message, type) and updates the messages state
immediately when the WebSocket event is received.